### PR TITLE
Authenticate requests for individual todos like other requests.

### DIFF
--- a/controllers/todoController.go
+++ b/controllers/todoController.go
@@ -18,6 +18,11 @@ import (
 var todoCollection *mongo.Collection = database.OpenCollection(database.Client, "todos")
 
 func GetTodo(c *gin.Context) {
+	session := auth.ValidateSession(c)
+	if !session{
+		return
+	}
+
 	var ctx, cancel = context.WithTimeout(context.Background(), 100*time.Second)
 
 	id := c.Param("id")


### PR DESCRIPTION
I noticed one of the todo controller functions does not authenticate sessions like the others. This allows unauthenticated users to access individual todos if they know or guess the todo ID.

This change adds session validation to this function.